### PR TITLE
move exception handling for label parsing

### DIFF
--- a/shared/src/main/scala/com/nawforce/pkgforce/stream/LabelGenerator.scala
+++ b/shared/src/main/scala/com/nawforce/pkgforce/stream/LabelGenerator.scala
@@ -57,12 +57,17 @@ object LabelGenerator {
                 .getChildren("labels")
                 .iterator
                 .flatMap(c => {
-                  val fullName: String = c.getSingleChildAsString("fullName")
-                  val protect: Boolean = c.getSingleChildAsBoolean("protected")
-                  Some(
-                    LabelEvent(PathLocation(document.path.toString, Location(c.line)),
-                               Name(fullName),
-                               protect))
+                  try {
+                    val fullName: String = c.getSingleChildAsString("fullName")
+                    val protect: Boolean = c.getSingleChildAsBoolean("protected")
+                    Some(
+                      LabelEvent(PathLocation(document.path.toString, Location(c.line)),
+                        Name(fullName),
+                        protect))
+                  } catch {
+                    case e: XMLException =>
+                      Iterator(IssuesEvent(Issue(document.path, ERROR_CATEGORY, e.where, e.msg)))
+                  }
                 })
               labels ++ Iterator(LabelFileEvent(SourceInfo(document.path, source)))
             } catch {


### PR DESCRIPTION
The iterator introduced in line 58 *seems* to defer the evaluation of the flatMap to outside a handler for XMLExceptions.

I've copied the exception handling into the flatMap to handle each case of where labels elements have missing elements. A possibly better solution would be to use the methods that return Option and handle the None returns.